### PR TITLE
Improve URL & Fix Pipeline limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.1.3 - 20-08-2022
+* enhancements
+  * Improved the URL formatting for deeply nested directories & files
+* bug fixes
+* fixes assets pipeline limitation. adds support for PropShaft etc.
+
 ### 0.1.2 - 12-03-2022
 * enhancements
   * Added Rspec & Capybara

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'puma'
 gem 'sprockets-rails'
 gem 'rspec-rails'
 gem 'capybara'
+gem 'byebug'
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.36.0)
       addressable
       matrix
@@ -200,6 +201,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  byebug
   capybara
   pg
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    templates-rails (0.1.2)
+    templates-rails (0.1.3)
       rails
 
 GEM
@@ -183,9 +183,9 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    strscan (3.0.1)
+    strscan (3.0.4)
     thor (1.2.1)
-    timeout (0.2.0)
+    timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.5)

--- a/app/views/templates/nested_index.html.erb
+++ b/app/views/templates/nested_index.html.erb
@@ -2,6 +2,6 @@
 
 <div>
   <% Dir.children("./app/views/templates/#{params[:id]}").excluding('partials').sort.each do |child| %>
-    <%= link_to child.chomp('.html.erb').humanize.titleize, templates_engine.template_path("#{params[:id]}/#{child.chomp('.html.erb')}"), class: 'button button--blue' %>
+    <%= link_to child.chomp('.html.erb').humanize.titleize, templates_engine.template_path('') + params[:id] + '/' + child.chomp('.html.erb'), class: 'button button--blue' %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Templates::Engine.routes.draw do
   root 'templates#index'
-  get ':id', to: 'templates#show', as: :template
+  get ':id', to: 'templates#show', as: :template, constraints: { id: /.*/ }
 end

--- a/lib/templates/engine.rb
+++ b/lib/templates/engine.rb
@@ -6,8 +6,10 @@ module Templates
       end
     end
 
-    initializer 'templates.assets.precompile' do |app|
-      app.config.assets.precompile += %w( templates/application.css )
+    initializer 'templates.assets' do
+      if Rails.application.config.respond_to?(:assets)
+        Rails.application.config.assets.precompile += %w( templates/application.css )
+      end
     end
   end
 end

--- a/lib/templates/version.rb
+++ b/lib/templates/version.rb
@@ -1,3 +1,3 @@
 module Templates
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
- added byebug. Not sure why it wasn't already in
- improved the URL formats, so the slashes aren't replaced by a url-safe char representation of `/`
  - added id constraint to routes
- updated the changelog
- and fixes the assets pipeline limitation. Follow up from this conversation; https://github.com/kirillplatonov/hotwire-livereload/pull/18

![CleanShot 2022-08-20 at 09 23 51](https://user-images.githubusercontent.com/32838548/185736187-079baf1c-e6e9-4f42-ad2a-deb196de712f.png)

Fixes #12